### PR TITLE
avcodec/bsf: mention that av_bsf_send_packet() returning EAGAIN is no…

### DIFF
--- a/libavcodec/bsf.h
+++ b/libavcodec/bsf.h
@@ -182,8 +182,9 @@ int av_bsf_init(AVBSFContext *ctx);
  * sending more empty packets does nothing) and will cause the filter to output
  * any packets it may have buffered internally.
  *
- * @return 0 on success, a negative AVERROR on error. This function never fails if
- * pkt is empty.
+ * @return 0 on success. AVERROR(EAGAIN) if packets need to be retrieved from the
+ * filter (using av_bsf_receive_packet()) before new input can be consumed. Another
+ * negative AVERROR value if an error occurs.
  */
 int av_bsf_send_packet(AVBSFContext *ctx, AVPacket *pkt);
 


### PR DESCRIPTION
…t an error

EAGAIN is returned when input is provided but can't be consumed. The filtering
process is unaffected in this case, and the function will be able to consume
new input after retrieving filtered packets with av_bsf_receive_packet().

Remove the line about empty packets never failing added in
41b05b849f215b03eeb9e3608571ba47de64182a while at it. Even if it's currently
the case, it unnecessarily constrains the API and could be changed in the future
in case it needs to be extended.
The user should always check for errors and never expect a call to never fail.

Reviewed-by: Derek Buitenhuis <derek.buitenhuis@gmail.com>
Signed-off-by: James Almer <jamrial@gmail.com>