### PR TITLE
avformat: Replace ffurl_close() by ffurl_closep() where appropriate

### DIFF
--- a/libavformat/async.c
+++ b/libavformat/async.c
@@ -293,7 +293,7 @@ cond_wakeup_background_fail:
 cond_wakeup_main_fail:
     pthread_mutex_destroy(&c->mutex);
 mutex_fail:
-    ffurl_close(c->inner);
+    ffurl_closep(&c->inner);
 url_fail:
     ring_destroy(&c->ring);
 fifo_fail:
@@ -317,7 +317,7 @@ static int async_close(URLContext *h)
     pthread_cond_destroy(&c->cond_wakeup_background);
     pthread_cond_destroy(&c->cond_wakeup_main);
     pthread_mutex_destroy(&c->mutex);
-    ffurl_close(c->inner);
+    ffurl_closep(&c->inner);
     ring_destroy(&c->ring);
 
     return 0;

--- a/libavformat/cache.c
+++ b/libavformat/cache.c
@@ -310,7 +310,7 @@ static int cache_close(URLContext *h)
             av_log(h, AV_LOG_ERROR, "Could not delete %s.\n", c->filename);
         av_freep(&c->filename);
     }
-    ffurl_close(c->inner);
+    ffurl_closep(&c->inner);
     av_tree_enumerate(c->root, NULL, NULL, enu_free);
     av_tree_destroy(c->root);
 

--- a/libavformat/concat.c
+++ b/libavformat/concat.c
@@ -49,7 +49,7 @@ static av_cold int concat_close(URLContext *h)
     struct concat_nodes *nodes = data->nodes;
 
     for (i = 0; i != data->length; i++)
-        err |= ffurl_close(nodes[i].uc);
+        err |= ffurl_closep(&nodes[i].uc);
 
     av_freep(&data->nodes);
 

--- a/libavformat/crypto.c
+++ b/libavformat/crypto.c
@@ -385,8 +385,7 @@ static int crypto_close(URLContext *h)
         ret = ffurl_write(c->hd, out_buf, BLOCKSIZE);
     }
 
-    if (c->hd)
-        ffurl_close(c->hd);
+    ffurl_closep(&c->hd);
     av_freep(&c->aes_decrypt);
     av_freep(&c->aes_encrypt);
     av_freep(&c->write_buf);

--- a/libavformat/gopher.c
+++ b/libavformat/gopher.c
@@ -68,10 +68,7 @@ static int gopher_connect(URLContext *h, const char *path)
 static int gopher_close(URLContext *h)
 {
     GopherContext *s = h->priv_data;
-    if (s->hd) {
-        ffurl_close(s->hd);
-        s->hd = NULL;
-    }
+    ffurl_closep(&s->hd);
     return 0;
 }
 

--- a/libavformat/hlsproto.c
+++ b/libavformat/hlsproto.c
@@ -178,7 +178,7 @@ static int hls_close(URLContext *h)
 
     free_segment_list(s);
     free_variant_list(s);
-    ffurl_close(s->seg_hd);
+    ffurl_closep(&s->seg_hd);
     return 0;
 }
 
@@ -260,8 +260,7 @@ start:
             return ret;
     }
     if (s->seg_hd) {
-        ffurl_close(s->seg_hd);
-        s->seg_hd = NULL;
+        ffurl_closep(&s->seg_hd);
         s->cur_seq_no++;
     }
     reload_interval = s->n_segments > 0 ?

--- a/libavformat/icecast.c
+++ b/libavformat/icecast.c
@@ -75,8 +75,7 @@ static void cat_header(AVBPrint *bp, const char key[], const char value[])
 static int icecast_close(URLContext *h)
 {
     IcecastContext *s = h->priv_data;
-    if (s->hd)
-        ffurl_close(s->hd);
+    ffurl_closep(&s->hd);
     return 0;
 }
 

--- a/libavformat/mmsh.c
+++ b/libavformat/mmsh.c
@@ -65,8 +65,7 @@ static int mmsh_close(URLContext *h)
 {
     MMSHContext *mmsh = (MMSHContext *)h->priv_data;
     MMSContext *mms   = &mmsh->mms;
-    if (mms->mms_hd)
-        ffurl_closep(&mms->mms_hd);
+    ffurl_closep(&mms->mms_hd);
     av_freep(&mms->streams);
     av_freep(&mms->asf_header);
     return 0;
@@ -265,7 +264,7 @@ static int mmsh_open_internal(URLContext *h, const char *uri, int flags, int tim
     }
 
     // close the socket and then reopen it for sending the second play request.
-    ffurl_close(mms->mms_hd);
+    ffurl_closep(&mms->mms_hd);
     memset(headers, 0, sizeof(headers));
     if ((err = ffurl_alloc(&mms->mms_hd, httpname, AVIO_FLAG_READ,
                            &h->interrupt_callback)) < 0) {

--- a/libavformat/mmst.c
+++ b/libavformat/mmst.c
@@ -473,7 +473,7 @@ static int mms_close(URLContext *h)
     MMSContext *mms   = &mmst->mms;
     if(mms->mms_hd) {
         send_close_packet(mmst);
-        ffurl_close(mms->mms_hd);
+        ffurl_closep(&mms->mms_hd);
     }
 
     /* free all separately allocated pointers in mms */

--- a/libavformat/rtmpcrypt.c
+++ b/libavformat/rtmpcrypt.c
@@ -240,7 +240,7 @@ static int rtmpe_close(URLContext *h)
     RTMPEContext *rt = h->priv_data;
 
     ff_dh_free(rt->dh);
-    ffurl_close(rt->stream);
+    ffurl_closep(&rt->stream);
 
     return 0;
 }

--- a/libavformat/rtmphttp.c
+++ b/libavformat/rtmphttp.c
@@ -176,7 +176,7 @@ static int rtmp_http_close(URLContext *h)
     }
 
     av_freep(&rt->out_data);
-    ffurl_close(rt->stream);
+    ffurl_closep(&rt->stream);
 
     return ret;
 }

--- a/libavformat/rtmpproto.c
+++ b/libavformat/rtmpproto.c
@@ -2511,7 +2511,7 @@ static int rtmp_close(URLContext *h)
 
     free_tracked_methods(rt);
     av_freep(&rt->flv_data);
-    ffurl_close(rt->stream);
+    ffurl_closep(&rt->stream);
     return ret;
 }
 
@@ -2824,8 +2824,7 @@ reconnect:
 
     if (rt->do_reconnect) {
         int i;
-        ffurl_close(rt->stream);
-        rt->stream       = NULL;
+        ffurl_closep(&rt->stream);
         rt->do_reconnect = 0;
         rt->nb_invokes   = 0;
         for (i = 0; i < 2; i++)

--- a/libavformat/rtpproto.c
+++ b/libavformat/rtpproto.c
@@ -363,10 +363,8 @@ static int rtp_open(URLContext *h, const char *uri, int flags)
     return 0;
 
  fail:
-    if (s->rtp_hd)
-        ffurl_close(s->rtp_hd);
-    if (s->rtcp_hd)
-        ffurl_close(s->rtcp_hd);
+    ffurl_closep(&s->rtp_hd);
+    ffurl_closep(&s->rtcp_hd);
     ffurl_closep(&s->fec_hd);
     av_free(fec_protocol);
     av_dict_free(&fec_opts);
@@ -506,8 +504,8 @@ static int rtp_close(URLContext *h)
 
     ff_ip_reset_filters(&s->filters);
 
-    ffurl_close(s->rtp_hd);
-    ffurl_close(s->rtcp_hd);
+    ffurl_closep(&s->rtp_hd);
+    ffurl_closep(&s->rtcp_hd);
     ffurl_closep(&s->fec_hd);
     return 0;
 }

--- a/libavformat/sapdec.c
+++ b/libavformat/sapdec.c
@@ -54,8 +54,7 @@ static int sap_read_close(AVFormatContext *s)
     struct SAPState *sap = s->priv_data;
     if (sap->sdp_ctx)
         avformat_close_input(&sap->sdp_ctx);
-    if (sap->ann_fd)
-        ffurl_close(sap->ann_fd);
+    ffurl_closep(&sap->ann_fd);
     av_freep(&sap->sdp);
     ff_network_close();
     return 0;

--- a/libavformat/sapenc.c
+++ b/libavformat/sapenc.c
@@ -60,8 +60,7 @@ static int sap_write_close(AVFormatContext *s)
     }
 
     av_freep(&sap->ann);
-    if (sap->ann_fd)
-        ffurl_close(sap->ann_fd);
+    ffurl_closep(&sap->ann_fd);
     ff_network_close();
     return 0;
 }

--- a/libavformat/srtpproto.c
+++ b/libavformat/srtpproto.c
@@ -59,8 +59,7 @@ static int srtp_close(URLContext *h)
     SRTPProtoContext *s = h->priv_data;
     ff_srtp_free(&s->srtp_out);
     ff_srtp_free(&s->srtp_in);
-    ffurl_close(s->rtp_hd);
-    s->rtp_hd = NULL;
+    ffurl_closep(&s->rtp_hd);
     return 0;
 }
 

--- a/libavformat/subfile.c
+++ b/libavformat/subfile.c
@@ -86,7 +86,7 @@ static int subfile_open(URLContext *h, const char *filename, int flags,
         return ret;
     c->pos = c->start;
     if ((ret = slave_seek(h)) < 0) {
-        ffurl_close(c->h);
+        ffurl_closep(&c->h);
         return ret;
     }
     return 0;
@@ -95,7 +95,7 @@ static int subfile_open(URLContext *h, const char *filename, int flags,
 static int subfile_close(URLContext *h)
 {
     SubfileContext *c = h->priv_data;
-    return ffurl_close(c->h);
+    return ffurl_closep(&c->h);
 }
 
 static int subfile_read(URLContext *h, unsigned char *buf, int size)

--- a/libavformat/tls_gnutls.c
+++ b/libavformat/tls_gnutls.c
@@ -100,8 +100,7 @@ static int tls_close(URLContext *h)
         gnutls_deinit(c->session);
     if (c->cred)
         gnutls_certificate_free_credentials(c->cred);
-    if (c->tls_shared.tcp)
-        ffurl_close(c->tls_shared.tcp);
+    ffurl_closep(&c->tls_shared.tcp);
     ff_gnutls_deinit();
     return 0;
 }

--- a/libavformat/tls_libtls.c
+++ b/libavformat/tls_libtls.c
@@ -44,8 +44,7 @@ static int ff_tls_close(URLContext *h)
         tls_close(p->ctx);
         tls_free(p->ctx);
     }
-    if (p->tls_shared.tcp)
-        ffurl_close(p->tls_shared.tcp);
+    ffurl_closep(&p->tls_shared.tcp);
     return 0;
 }
 

--- a/libavformat/tls_openssl.c
+++ b/libavformat/tls_openssl.c
@@ -142,8 +142,7 @@ static int tls_close(URLContext *h)
     }
     if (c->ctx)
         SSL_CTX_free(c->ctx);
-    if (c->tls_shared.tcp)
-        ffurl_close(c->tls_shared.tcp);
+    ffurl_closep(&c->tls_shared.tcp);
 #if OPENSSL_VERSION_NUMBER >= 0x1010000fL
     if (c->url_bio_method)
         BIO_meth_free(c->url_bio_method);

--- a/libavformat/tls_schannel.c
+++ b/libavformat/tls_schannel.c
@@ -138,8 +138,7 @@ static int tls_close(URLContext *h)
     av_freep(&c->dec_buf);
     c->dec_buf_size = c->dec_buf_offset = 0;
 
-    if (c->tls_shared.tcp)
-        ffurl_close(c->tls_shared.tcp);
+    ffurl_closep(&c->tls_shared.tcp);
     return 0;
 }
 

--- a/libavformat/tls_securetransport.c
+++ b/libavformat/tls_securetransport.c
@@ -251,8 +251,7 @@ static int tls_close(URLContext *h)
     }
     if (c->ca_array)
         CFRelease(c->ca_array);
-    if (c->tls_shared.tcp)
-        ffurl_close(c->tls_shared.tcp);
+    ffurl_closep(&c->tls_shared.tcp);
     return 0;
 }
 


### PR DESCRIPTION
It avoids leaving dangling pointers behind in memory.

Also remove redundant checks for whether the URLContext to be closed is
already NULL.

Reviewed-by: Anton Khirnov <anton@khirnov.net>
Signed-off-by: Andreas Rheinhardt <andreas.rheinhardt@gmail.com>