### PR TITLE
lavfi/vulkan: use av_get_random_seed instead of rand

### DIFF
--- a/libavfilter/vf_avgblur_vulkan.c
+++ b/libavfilter/vf_avgblur_vulkan.c
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "libavutil/random_seed.h"
 #include "libavutil/opt.h"
 #include "vulkan.h"
 #include "internal.h"
@@ -99,7 +100,7 @@ static av_cold int init_filter(AVFilterContext *ctx, AVFrame *in)
 
     s->vkctx.queue_family_idx = s->vkctx.hwctx->queue_family_comp_index;
     s->vkctx.queue_count = GET_QUEUE_COUNT(s->vkctx.hwctx, 0, 1, 0);
-    s->vkctx.cur_queue_idx = rand() % s->vkctx.queue_count;
+    s->vkctx.cur_queue_idx = av_get_random_seed() % s->vkctx.queue_count;
 
     { /* Create shader for the horizontal pass */
         desc_i[0].updater = s->input_images;

--- a/libavfilter/vf_chromaber_vulkan.c
+++ b/libavfilter/vf_chromaber_vulkan.c
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "libavutil/random_seed.h"
 #include "libavutil/opt.h"
 #include "vulkan.h"
 #include "internal.h"
@@ -75,7 +76,7 @@ static av_cold int init_filter(AVFilterContext *ctx, AVFrame *in)
 
     s->vkctx.queue_family_idx = s->vkctx.hwctx->queue_family_comp_index;
     s->vkctx.queue_count = GET_QUEUE_COUNT(s->vkctx.hwctx, 0, 1, 0);
-    s->vkctx.cur_queue_idx = rand() % s->vkctx.queue_count;
+    s->vkctx.cur_queue_idx = av_get_random_seed() % s->vkctx.queue_count;
 
     s->pl = ff_vk_create_pipeline(ctx);
     if (!s->pl)

--- a/libavfilter/vf_overlay_vulkan.c
+++ b/libavfilter/vf_overlay_vulkan.c
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "libavutil/random_seed.h"
 #include "libavutil/opt.h"
 #include "vulkan.h"
 #include "internal.h"
@@ -89,7 +90,7 @@ static av_cold int init_filter(AVFilterContext *ctx)
 
     s->vkctx.queue_family_idx = s->vkctx.hwctx->queue_family_comp_index;
     s->vkctx.queue_count = GET_QUEUE_COUNT(s->vkctx.hwctx, 0, 1, 0);
-    s->vkctx.cur_queue_idx = rand() % s->vkctx.queue_count;
+    s->vkctx.cur_queue_idx = av_get_random_seed() % s->vkctx.queue_count;
 
     { /* Create the shader */
         const int planes = av_pix_fmt_count_planes(s->vkctx.output_format);

--- a/libavfilter/vf_scale_vulkan.c
+++ b/libavfilter/vf_scale_vulkan.c
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "libavutil/random_seed.h"
 #include "libavutil/opt.h"
 #include "vulkan.h"
 #include "scale_eval.h"
@@ -117,7 +118,7 @@ static av_cold int init_filter(AVFilterContext *ctx, AVFrame *in)
 
     s->vkctx.queue_family_idx = s->vkctx.hwctx->queue_family_comp_index;
     s->vkctx.queue_count = GET_QUEUE_COUNT(s->vkctx.hwctx, 0, 1, 0);
-    s->vkctx.cur_queue_idx = rand() % s->vkctx.queue_count;
+    s->vkctx.cur_queue_idx = av_get_random_seed() % s->vkctx.queue_count;
 
     switch (s->scaler) {
     case F_NEAREST:


### PR DESCRIPTION
We need at least a few bits of entropy to determine the start index of each
queue, in order to let filters run in parallel as much as possible, and
rand() is not thread safe and disrupts any external API's usage of rand,
so instead replace it with av_get_random_seed.
While it has more overhead than rand, we only run it once per filter upon init.