### PR TITLE
avcodec/jpegls: Remove unused structure

### DIFF
--- a/libavcodec/jpegls.h
+++ b/libavcodec/jpegls.h
@@ -34,10 +34,6 @@
 
 #undef near /* This file uses struct member 'near' which in windows.h is defined as empty. */
 
-typedef struct JpeglsContext {
-    AVCodecContext *avctx;
-} JpeglsContext;
-
 typedef struct JLSState {
     int T1, T2, T3;
     int A[367], B[367], C[365], N[367];


### PR DESCRIPTION
Reviewed-by: Michael Niedermayer <michael@niedermayer.cc>
Signed-off-by: Andreas Rheinhardt <andreas.rheinhardt@gmail.com>