### PR TITLE
lavc/qsvdec: Add QSV AV1 decoder

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -28,6 +28,7 @@ version <next>:
 - DAT demuxer
 - aax demuxer
 - IPU decoder, parser and demuxer
+- Intel QSV-accelerated AV1 decoding
 
 
 version 4.3:

--- a/configure
+++ b/configure
@@ -3140,6 +3140,7 @@ vp9_qsv_encoder_deps="libmfx MFX_CODEC_VP9"
 vp9_qsv_encoder_select="qsvenc"
 vp9_v4l2m2m_decoder_deps="v4l2_m2m vp9_v4l2_m2m"
 wmv3_crystalhd_decoder_select="crystalhd"
+av1_qsv_decoder_select="qsvdec"
 
 # parsers
 aac_parser_select="adts_header"

--- a/libavcodec/allcodecs.c
+++ b/libavcodec/allcodecs.c
@@ -821,6 +821,7 @@ extern AVCodec ff_vp9_mediacodec_decoder;
 extern AVCodec ff_vp9_qsv_decoder;
 extern AVCodec ff_vp9_vaapi_encoder;
 extern AVCodec ff_vp9_qsv_encoder;
+extern AVCodec ff_av1_qsv_decoder;
 
 // The iterate API is not usable with ossfuzz due to the excessive size of binaries created
 #if CONFIG_OSSFUZZ

--- a/libavcodec/qsv.c
+++ b/libavcodec/qsv.c
@@ -64,6 +64,10 @@ int ff_qsv_codec_id_to_mfx(enum AVCodecID codec_id)
     case AV_CODEC_ID_VP9:
         return MFX_CODEC_VP9;
 #endif
+#if QSV_VERSION_ATLEAST(1, 34)
+    case AV_CODEC_ID_AV1:
+        return MFX_CODEC_AV1;
+#endif
 
     default:
         break;

--- a/libavcodec/qsvdec_other.c
+++ b/libavcodec/qsvdec_other.c
@@ -1,5 +1,5 @@
 /*
- * Intel MediaSDK QSV based MPEG-2, VC-1, VP8, MJPEG and VP9 decoders
+ * Intel MediaSDK QSV based MPEG-2, VC-1, VP8, MJPEG, VP9 and AV1 decoders
  *
  * copyright (c) 2015 Anton Khirnov
  *
@@ -319,6 +319,35 @@ AVCodec ff_vp9_qsv_decoder = {
     .close          = qsv_decode_close,
     .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_DR1 | AV_CODEC_CAP_AVOID_PROBING | AV_CODEC_CAP_HYBRID,
     .priv_class     = &vp9_qsv_class,
+    .pix_fmts       = (const enum AVPixelFormat[]){ AV_PIX_FMT_NV12,
+                                                    AV_PIX_FMT_P010,
+                                                    AV_PIX_FMT_QSV,
+                                                    AV_PIX_FMT_NONE },
+    .hw_configs     = ff_qsv_hw_configs,
+    .wrapper_name   = "qsv",
+};
+#endif
+
+#if CONFIG_AV1_QSV_DECODER
+static const AVClass av1_qsv_class = {
+    .class_name = "av1_qsv",
+    .item_name  = av_default_item_name,
+    .option     = options,
+    .version    = LIBAVUTIL_VERSION_INT,
+};
+
+AVCodec ff_av1_qsv_decoder = {
+    .name           = "av1_qsv",
+    .long_name      = NULL_IF_CONFIG_SMALL("AV1 video (Intel Quick Sync Video acceleration)"),
+    .priv_data_size = sizeof(QSVOtherContext),
+    .type           = AVMEDIA_TYPE_VIDEO,
+    .id             = AV_CODEC_ID_AV1,
+    .init           = qsv_decode_init,
+    .decode         = qsv_decode_frame,
+    .flush          = qsv_decode_flush,
+    .close          = qsv_decode_close,
+    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_DR1 | AV_CODEC_CAP_AVOID_PROBING | AV_CODEC_CAP_HYBRID,
+    .priv_class     = &av1_qsv_class,
     .pix_fmts       = (const enum AVPixelFormat[]){ AV_PIX_FMT_NV12,
                                                     AV_PIX_FMT_P010,
                                                     AV_PIX_FMT_QSV,


### PR DESCRIPTION
AV1 decoder is supported on Tiger Lake+ platforms since libmfx 1.34

Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
Signed-off-by: Zhong Li <zhongli_dev@126.com>