### PR TITLE
avfilter/vf_v360: use quaternions for rotation

### DIFF
--- a/libavfilter/v360.h
+++ b/libavfilter/v360.h
@@ -150,7 +150,7 @@ typedef struct V360Context {
     float flat_range[2];
     float iflat_range[2];
 
-    float rot_mat[3][3];
+    float rot_quaternion[2][4];
 
     float output_mirror_modifier[3];
 


### PR DESCRIPTION
Fixes gimbal lock issues, and round-off errors.