### PR TITLE
avcodec/magicyuv: Check slice size before reading flags and pred

### DIFF
--- a/libavcodec/magicyuv.c
+++ b/libavcodec/magicyuv.c
@@ -623,6 +623,9 @@ static int magy_decode_frame(AVCodecContext *avctx, void *data,
 
         s->slices[i][j].start = offset + header_size;
         s->slices[i][j].size  = avpkt->size - s->slices[i][j].start;
+
+        if (s->slices[i][j].size < 2)
+            return AVERROR_INVALIDDATA;
     }
 
     if (bytestream2_get_byteu(&gb) != s->planes)


### PR DESCRIPTION
Fixes: heap-buffer-overflow
Fixes: 26487/clusterfuzz-testcase-minimized-ffmpeg_AV_CODEC_ID_MAGICYUV_fuzzer-5742553675333632

Found-by: continuous fuzzing process https://github.com/google/oss-fuzz/tree/master/projects/ffmpeg
Reviewed-by: Andreas Rheinhardt <andreas.rheinhardt@gmail.com>
Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>