### PR TITLE
lavf/url: fix relative url parsing when the query string or fragment …

### DIFF
--- a/libavformat/tests/url.c
+++ b/libavformat/tests/url.c
@@ -90,6 +90,8 @@ int main(void)
     test_decompose("http://[::1]/dev/null");
     test_decompose("http://[::1]:8080/dev/null");
     test_decompose("//ffmpeg/dev/null");
+    test_decompose("test?url=http://server/path");
+    test_decompose("dummy.mp4#t=0:02:00,121.5");
 
     printf("Testing ff_make_absolute_url:\n");
     test(NULL, "baz");

--- a/libavformat/url.c
+++ b/libavformat/url.c
@@ -97,7 +97,7 @@ int ff_url_decompose(URLComponents *uc, const char *url, const char *end)
 
     /* scheme */
     uc->scheme = cur;
-    p = find_delim(":/", cur, end); /* lavf "schemes" can contain options */
+    p = find_delim(":/?#", cur, end); /* lavf "schemes" can contain options but not some RFC 3986 delimiters */
     if (*p == ':')
         cur = p + 1;
 

--- a/tests/ref/fate/url
+++ b/tests/ref/fate/url
@@ -43,6 +43,14 @@ http://[::1]:8080/dev/null =>
   host: ffmpeg
   path: /dev/null
 
+test?url=http://server/path =>
+  path: test
+  query: ?url=http://server/path
+
+dummy.mp4#t=0:02:00,121.5 =>
+  path: dummy.mp4
+  fragment: #t=0:02:00,121.5
+
 Testing ff_make_absolute_url:
                                             (null) baz                  => baz
                                           /foo/bar baz                  => /foo/baz


### PR DESCRIPTION
…has a colon

This disallows the usage of ? and # in libavformat specific scheme options
(e.g. subfile,,start,32815239,end,0,,:video.ts) but this change was considered
acceptable.

Signed-off-by: ruiquan.crq <caihaoning83@gmail.com>
Signed-off-by: Marton Balint <cus@passwd.hu>