### PR TITLE
tools/target_dem_fuzzer: Consider it an EIO when reading position wra…

### DIFF
--- a/tools/target_dem_fuzzer.c
+++ b/tools/target_dem_fuzzer.c
@@ -49,6 +49,8 @@ static int io_read(void *opaque, uint8_t *buf, int buf_size)
         c->filesize = FFMIN(c->pos, c->filesize);
         return AVERROR_EOF;
     }
+    if (c->pos > INT64_MAX - size)
+        return AVERROR(EIO);
 
     memcpy(buf, c->fuzz, size);
     c->fuzz      += size;


### PR DESCRIPTION
…ps around 64bit

Fixes: signed integer overflow: 9223372036854775807 + 564 cannot be represented in type 'long'
Fixes: 26494/clusterfuzz-testcase-minimized-ffmpeg_dem_VOC_fuzzer-576754158849228
Fixes: 26549/clusterfuzz-testcase-minimized-ffmpeg_dem_AVS_fuzzer-4844306424397824
FIxes: 26875/clusterfuzz-testcase-minimized-ffmpeg_dem_C93_fuzzer-5996226782429184

Found-by: continuous fuzzing process https://github.com/google/oss-fuzz/tree/master/projects/ffmpeg
Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>