### PR TITLE
avcodec/gdv: Remove dead check

### DIFF
--- a/libavcodec/gdv.c
+++ b/libavcodec/gdv.c
@@ -551,7 +551,7 @@ static int gdv_decode_frame(AVCodecContext *avctx, void *data,
 
     *got_frame = 1;
 
-    return ret < 0 ? ret : avpkt->size;
+    return avpkt->size;
 }
 
 static av_cold int gdv_decode_close(AVCodecContext *avctx)


### PR DESCRIPTION
At the end of its decode function, the decoder sets *got_frame to 1 and
then checks whether ret is < 0; if so, it is returned, otherwise
avpkt->size is. But it is impossible for ret to be < 0 here and if it
were, it would be nonsense to set *got_frame to 1 before this. Therefore
just return avpkt->size unconditionally.

Fixes Coverity issue #1439730.

Reviewed-by: Paul B Mahol <onemda@gmail.com>
Signed-off-by: Andreas Rheinhardt <andreas.rheinhardt@gmail.com>