### PR TITLE
lavu/tx: require output argument to match input for inplace transforms

### DIFF
--- a/libavutil/tx.h
+++ b/libavutil/tx.h
@@ -103,8 +103,8 @@ typedef void (*av_tx_fn)(AVTXContext *s, void *out, void *in, ptrdiff_t stride);
  */
 enum AVTXFlags {
     /**
-     * Performs an in-place transformation on the input. The output parameter
-     * to av_tn_fn() will be ignored. May be unsupported or slower for some
+     * Performs an in-place transformation on the input. The output argument
+     * of av_tn_fn() MUST match the input. May be unsupported or slower for some
      * transform types.
      */
     AV_TX_INPLACE = 1ULL << 0,

--- a/libavutil/tx_template.c
+++ b/libavutil/tx_template.c
@@ -397,7 +397,6 @@ static void monolithic_fft(AVTXContext *s, void *_out, void *_in,
         FFTComplex tmp;
         int src, dst, *inplace_idx = s->inplace_idx;
 
-        out = in;
         src = *inplace_idx++;
 
         do {


### PR DESCRIPTION
This simplifies some assembly code by a lot, by either saving a branch
or saving an entire duplicated function.